### PR TITLE
Refer to exisiting md-time-picker.js

### DIFF
--- a/demoApp/index.html
+++ b/demoApp/index.html
@@ -50,7 +50,7 @@
     <script src="https://ajax.googleapis.com/ajax/libs/angular_material/1.1.0/angular-material.min.js"></script>
 
     <script type="text/javascript" src="demoApp.js"></script>
-    <script type="text/javascript" src="../dist/md-time-picker.min.js"></script>
+    <script type="text/javascript" src="../dist/md-time-picker.js"></script>
 
   </body>
 </html>


### PR DESCRIPTION
The minified version of md-time-picker.js was not found in the project. Therefor change reference to md-time-picker.js