### PR TITLE
Allow md-time-picker to be placed inside an html <form> element

### DIFF
--- a/dist/md-time-picker.css
+++ b/dist/md-time-picker.css
@@ -1,19 +1,20 @@
-form[name=timeForm] {
+ng-form[name=timeForm] {
+  display: block;
   position: relative;
   vertical-align: middle;
 }
-form[name=timeForm]>* {
+ng-form[name=timeForm]>* {
   display: inline-block;
 }
-form[name=timeForm] input,
-form[name=timeForm] md-input-container {
+ng-form[name=timeForm] input,
+ng-form[name=timeForm] md-input-container {
   text-align: center;
   padding: 0;
 }
-form[name=timeForm] md-input-container .md-errors-spacer {
+ng-form[name=timeForm] md-input-container .md-errors-spacer {
   min-height: 0;
 }
-form[name=timeForm] div.time-error-messages {
+ng-form[name=timeForm] div.time-error-messages {
   position: absolute;
   top: 30px;
 }

--- a/dist/md-time-picker.js
+++ b/dist/md-time-picker.js
@@ -263,7 +263,7 @@
           readOnly: '<', // true or false
           mandatory: '<' // true or false
         },
-        template: '<form name="timeForm">' +
+        template: '<ng-form name="timeForm">' +
           '<button class="md-icon-button md-button md-ink-ripple" type="button" ng-click="!readOnly && showPicker($event)">' +
           '<md-icon>' +
           '<i class="material-icons">&#xE192;</i>' +
@@ -274,7 +274,7 @@
           '<span class="time-colon">:</span>' +
           '<md-hours-minutes type="MM" ng-model="ngModel" message="{{message.minute}}" read-only="readOnly" mandatory="mandatory"></md-hours-minutes>' +
           '<md-meridiem ng-if="!noMeridiem" ng-model="ngModel" message="{{message.meridiem}}" read-only="readOnly" mandatory="mandatory"></md-meridiem>' +
-          '</form>',
+          '</ng-form>',
         controller: ["$scope", "$rootScope", "$mdpTimePicker", "$attrs", function($scope, $rootScope, $mdpTimePicker, $attrs) {
 
           $scope.showPicker = function(ev) {


### PR DESCRIPTION
When I attempted to put a <md-time-picker> element inside a <form> element, the fact that the template already contained a form caused the browser to try to nest <form> elements.  This automatically throws out the inner form element, causing visual corruption and problems with error messaging.