### PR TITLE
Set the input-type of the hoursminutes-input to number

### DIFF
--- a/dist/md-time-picker.js
+++ b/dist/md-time-picker.js
@@ -69,7 +69,7 @@
         template: '<md-input-container md-no-float>' +
           '<input ' +
           'ng-required="mandatory" ' +
-          'type="text"' +
+          'type="number"' +
           'name="time_{{type}}"' +
           'ng-model="time[type]"' +
           'ng-change="handleInput()"' +


### PR DESCRIPTION
In the mobile context the opened virrtual keyboard is defined by the input type. 
For this reason and because hours and minutes can only be numbers this should be a number-input.