### PR TITLE
Fix #38: Browser's autocomplete stops the up and down keys from working

### DIFF
--- a/dist/md-time-picker.js
+++ b/dist/md-time-picker.js
@@ -70,6 +70,7 @@
           '<input ' +
           'ng-required="mandatory" ' +
           'type="text"' +
+          'autocomplete="off"' +
           'name="time_{{type}}"' +
           'ng-model="time[type]"' +
           'ng-change="handleInput()"' +


### PR DESCRIPTION
Changing the hours and minutes using the up and down keys does not work reliably if the browser's autocomplete functionality is enabled.

The autocomplete functionality is not needed anyway in the hours/minutes inputs.

Solution: Add attribute autocomplete="off" to hours/minutes inputs.

To replicate:

 - Enter some number(s) into the hours or minutes inputs
 - Confirm the number(s) (e.g. by chaging the focus)
 - Try to change the value using keyboard up and down keys
 - When you reach any of the previously entered values, the browser opens an autocompletion menu and the keyboard arrows no longer work as expected

 Tested on Chrome 68.0.3440.84 (Windows).